### PR TITLE
perf: ATS concurrency, brave cache, dashboard aggregations, health check (closes #8, #9, #12, #17, #21, #22)

### DIFF
--- a/src/app/actions/jobs.ts
+++ b/src/app/actions/jobs.ts
@@ -57,11 +57,26 @@ export async function updateJobStatus(savedJobId: string, status: string) {
   }
 
   try {
+    const newStatus = parsed.data.status;
+    let appliedAt: Date | null | undefined = undefined;
+
+    if (newStatus === "saved") {
+      appliedAt = null;
+    } else if (["applied", "interview", "offer"].includes(newStatus)) {
+      const existing = await prisma.savedJob.findUnique({
+        where: { id: savedJobId, userId: session.user.id },
+        select: { appliedAt: true },
+      });
+      if (!existing?.appliedAt) {
+        appliedAt = new Date();
+      }
+    }
+
     await prisma.savedJob.update({
       where: { id: savedJobId, userId: session.user.id },
       data: {
-        status: parsed.data.status,
-        appliedAt: parsed.data.status === "applied" ? new Date() : undefined,
+        status: newStatus,
+        ...(appliedAt !== undefined && { appliedAt }),
       },
     });
     return { success: true };

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
 
     const userId = session.user.id;
 
-    const [profile, recentSearches, topJobs, totalSearches, totalJobs, savedJobsCount, allJobs] =
+    const [profile, recentSearches, topJobs, totalSearches, totalJobs, savedJobsCount] =
       await Promise.all([
         prisma.profile.findUnique({
           where: { userId },
@@ -35,29 +35,46 @@ export async function GET() {
         prisma.search.count({ where: { userId } }),
         prisma.job.count({ where: { search: { userId } } }),
         prisma.savedJob.count({ where: { userId } }),
-        prisma.job.findMany({
-          where: { search: { userId }, atsScore: { not: null } },
-          select: { atsScore: true, missingSkills: true },
-        }),
       ]);
 
-    const scores: number[] = allJobs.map((j: { atsScore: number | null }) => j.atsScore!);
-    const avgScore =
-      scores.length > 0
-        ? Math.round(scores.reduce((a: number, b: number) => a + b, 0) / scores.length)
-        : 0;
+    // Aggregate avg score
+    const avgAgg = await prisma.job.aggregate({
+      where: { search: { userId }, atsScore: { not: null } },
+      _avg: { atsScore: true },
+    });
+    const avgScore = Math.round(avgAgg._avg.atsScore ?? 0);
 
-    const ranges = ["0-20", "21-40", "41-60", "61-80", "81-100"];
-    const scoreDistribution = ranges.map((range) => {
-      const [min, max] = range.split("-").map(Number);
-      return {
-        range,
-        count: scores.filter((s: number) => s >= min && s <= max).length,
-      };
+    // Score distribution via groupBy with raw ranges
+    const scoredJobs = await prisma.job.groupBy({
+      by: ["atsScore"],
+      where: { search: { userId }, atsScore: { not: null } },
+      _count: true,
+    });
+
+    const ranges = [
+      { range: "0-20", min: 0, max: 20 },
+      { range: "21-40", min: 21, max: 40 },
+      { range: "41-60", min: 41, max: 60 },
+      { range: "61-80", min: 61, max: 80 },
+      { range: "81-100", min: 81, max: 100 },
+    ];
+    const scoreDistribution = ranges.map(({ range, min, max }) => ({
+      range,
+      count: scoredJobs
+        .filter((g: { atsScore: number | null; _count: number }) => g.atsScore! >= min && g.atsScore! <= max)
+        .reduce((sum: number, g: { _count: number }) => sum + g._count, 0),
+    }));
+
+    // Top missing skills from a limited set of recent scored jobs
+    const recentScoredJobs = await prisma.job.findMany({
+      where: { search: { userId }, atsScore: { not: null } },
+      orderBy: { createdAt: "desc" },
+      take: 200,
+      select: { missingSkills: true },
     });
 
     const skillCounts: Record<string, number> = {};
-    for (const job of allJobs) {
+    for (const job of recentScoredJobs) {
       for (const skill of job.missingSkills) {
         skillCounts[skill] = (skillCounts[skill] || 0) + 1;
       }

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  let db = false;
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    db = true;
+  } catch {
+    // DB unreachable
+  }
+
+  const status = db ? "ok" : "degraded";
+  const statusCode = db ? 200 : 503;
+
+  return NextResponse.json(
+    { status, db, timestamp: new Date().toISOString() },
+    { status: statusCode }
+  );
+}

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -6,6 +6,7 @@ import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import { requireAuth, isAuthError, apiHandler, extractProfileForScoring } from "@/lib/api-utils";
 import { searchSchema } from "@/lib/validations";
 import { logger } from "@/lib/logger";
+import { pLimit } from "@/lib/utils";
 
 export async function POST(request: NextRequest) {
   return apiHandler("search/POST", async () => {
@@ -81,27 +82,30 @@ export async function POST(request: NextRequest) {
 
     if (profile) {
       const profileData = extractProfileForScoring(profile);
+      const limit = pLimit(3);
 
       await Promise.allSettled(
-        jobs.map(async (job: { id: string; title: string; description: string }) => {
-          try {
-            const score = await scoreJobATS(profileData, job.title, job.description);
-            await prisma.job.update({
-              where: { id: job.id },
-              data: {
-                atsScore: score.totalScore,
-                scoreBreakdown: JSON.parse(JSON.stringify(score.breakdown)),
-                matchingSkills: score.matchingSkills,
-                missingSkills: score.missingSkills,
-              },
-            });
-          } catch (err) {
-            logger.warn("ATS scoring failed for job", {
-              jobId: job.id,
-              error: err instanceof Error ? err : new Error(String(err)),
-            });
-          }
-        })
+        jobs.map((job: { id: string; title: string; description: string }) =>
+          limit(async () => {
+            try {
+              const score = await scoreJobATS(profileData, job.title, job.description);
+              await prisma.job.update({
+                where: { id: job.id },
+                data: {
+                  atsScore: score.totalScore,
+                  scoreBreakdown: JSON.parse(JSON.stringify(score.breakdown)),
+                  matchingSkills: score.matchingSkills,
+                  missingSkills: score.missingSkills,
+                },
+              });
+            } catch (err) {
+              logger.warn("ATS scoring failed for job", {
+                jobId: job.id,
+                error: err instanceof Error ? err : new Error(String(err)),
+              });
+            }
+          })
+        )
       );
     }
 

--- a/src/app/api/search/smart/route.ts
+++ b/src/app/api/search/smart/route.ts
@@ -5,6 +5,7 @@ import { scoreJobATS } from "@/lib/ai";
 import { checkRateLimit, RATE_LIMITS } from "@/lib/rate-limit";
 import { requireAuth, isAuthError, apiHandler, extractProfileForScoring } from "@/lib/api-utils";
 import { logger } from "@/lib/logger";
+import { pLimit } from "@/lib/utils";
 
 export async function POST() {
   return apiHandler("search/smart/POST", async () => {
@@ -132,27 +133,30 @@ export async function POST() {
     );
 
     const profileData = extractProfileForScoring(profile);
+    const limit = pLimit(3);
 
     await Promise.allSettled(
-      jobs.map(async (job: { id: string; title: string; description: string }) => {
-        try {
-          const score = await scoreJobATS(profileData, job.title, job.description);
-          await prisma.job.update({
-            where: { id: job.id },
-            data: {
-              atsScore: score.totalScore,
-              scoreBreakdown: JSON.parse(JSON.stringify(score.breakdown)),
-              matchingSkills: score.matchingSkills,
-              missingSkills: score.missingSkills,
-            },
-          });
-        } catch (err) {
-          logger.warn("Smart search ATS scoring failed", {
-            jobId: job.id,
-            error: err instanceof Error ? err : new Error(String(err)),
-          });
-        }
-      })
+      jobs.map((job: { id: string; title: string; description: string }) =>
+        limit(async () => {
+          try {
+            const score = await scoreJobATS(profileData, job.title, job.description);
+            await prisma.job.update({
+              where: { id: job.id },
+              data: {
+                atsScore: score.totalScore,
+                scoreBreakdown: JSON.parse(JSON.stringify(score.breakdown)),
+                matchingSkills: score.matchingSkills,
+                missingSkills: score.missingSkills,
+              },
+            });
+          } catch (err) {
+            logger.warn("Smart search ATS scoring failed", {
+              jobId: job.id,
+              error: err instanceof Error ? err : new Error(String(err)),
+            });
+          }
+        })
+      )
     );
 
     const scoredJobs = await prisma.job.findMany({

--- a/src/lib/brave-search.ts
+++ b/src/lib/brave-search.ts
@@ -1,4 +1,13 @@
+import crypto from "crypto";
 import { logger } from "@/lib/logger";
+
+// Simple in-memory cache with TTL for Brave search results
+const CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const searchCache = new Map<string, { data: ParsedJobResult[]; expiry: number }>();
+
+function getCacheKey(query: string, location?: string): string {
+  return crypto.createHash("md5").update(`${query}|${location ?? ""}`).digest("hex");
+}
 
 export interface BraveSearchResult {
   title: string;
@@ -118,6 +127,12 @@ export async function searchJobs(
   const apiKey = process.env.BRAVE_API_KEY;
   if (!apiKey) throw new Error("BRAVE_API_KEY non configuree");
 
+  const cacheKey = getCacheKey(`${query}|${remote ?? ""}|${contract ?? ""}|${count}`, location);
+  const cached = searchCache.get(cacheKey);
+  if (cached && cached.expiry > Date.now()) {
+    return cached.data;
+  }
+
   const sites = "site:linkedin.com/jobs/view OR site:indeed.fr/viewjob OR site:welcometothejungle.com/fr/companies/*/jobs/* OR site:apec.fr OR site:francetravail.fr";
   const locationQuery = location ? ` ${location}` : "";
   const remoteQuery = remote === "remote" ? " teletravail" : remote === "hybrid" ? " hybride" : "";
@@ -148,11 +163,15 @@ export async function searchJobs(
   const data = await response.json();
   const results: BraveSearchResult[] = data.web?.results || [];
 
-  return results
+  const parsed = results
     .filter((r) => !isAggregatedResult(r))
     .filter((r) => isIndividualJobUrl(r.url))
     .map(parseJobFromResult)
     .slice(0, count);
+
+  searchCache.set(cacheKey, { data: parsed, expiry: Date.now() + CACHE_TTL_MS });
+
+  return parsed;
 }
 
 export async function fetchJobDescription(url: string): Promise<string> {

--- a/src/lib/db-cleanup.ts
+++ b/src/lib/db-cleanup.ts
@@ -48,19 +48,27 @@ export async function cleanupOldSearches(): Promise<{
 
     const searchIds = oldSearches.map((s: { id: string }) => s.id);
 
-    // Delete saved jobs referencing jobs from these searches
-    await prisma.savedJob.deleteMany({
-      where: { job: { searchId: { in: searchIds } } },
+    // Skip searches that have jobs with SavedJobs
+    const searchesWithSavedJobs = await prisma.search.findMany({
+      where: {
+        id: { in: searchIds },
+        results: { some: { savedJobs: { some: {} } } },
+      },
+      select: { id: true },
     });
+    const savedSearchIds = new Set(searchesWithSavedJobs.map((s: { id: string }) => s.id));
+    const deletableSearchIds = searchIds.filter((id: string) => !savedSearchIds.has(id));
+
+    if (deletableSearchIds.length === 0) continue;
 
     // Delete jobs from these searches
     const deletedJobs = await prisma.job.deleteMany({
-      where: { searchId: { in: searchIds } },
+      where: { searchId: { in: deletableSearchIds } },
     });
 
     // Delete the searches themselves
     const deletedSearches = await prisma.search.deleteMany({
-      where: { id: { in: searchIds } },
+      where: { id: { in: deletableSearchIds } },
     });
 
     totalDeletedSearches += deletedSearches.count;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,30 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Limits concurrent async operations to a given concurrency level.
+ */
+export function pLimit(concurrency: number) {
+  let active = 0;
+  const queue: (() => void)[] = [];
+
+  function next() {
+    if (queue.length > 0 && active < concurrency) {
+      active++;
+      queue.shift()!();
+    }
+  }
+
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    return new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        fn().then(resolve, reject).finally(() => {
+          active--;
+          next();
+        });
+      });
+      next();
+    });
+  };
+}


### PR DESCRIPTION
## Changes
- **#8** Limited ATS scoring to 3 concurrent Claude calls (pLimit)
- **#9** Cleanup skips searches with active SavedJobs
- **#12** Dashboard uses Prisma aggregations instead of loading all jobs
- **#17** Brave Search cache (10min TTL, MD5 key)
- **#21** Health check endpoint (/api/health)
- **#22** appliedAt logic: reset on saved, set on applied/interview/offer

Severity: High